### PR TITLE
fixed german umlaut issue for several charsets

### DIFF
--- a/lib/helpers/getMessage.js
+++ b/lib/helpers/getMessage.js
@@ -16,9 +16,10 @@ var isHeader = /^HEADER/g;
  * }
  *
  * @param {object} message an ImapMessage from the node-imap library
+ * @param {string} [charset] optional string of the charset
  * @returns {Promise} a promise resolving to `message` with schema as described above
  */
-module.exports = function getMessage(message) {
+module.exports = function getMessage(message, charset) {
     return new Promise(function (resolve) {
         var attributes;
         var messageParts = [];
@@ -53,7 +54,7 @@ module.exports = function getMessage(message) {
             message.removeListener('body', messageOnBody);
             message.removeListener('attributes', messageOnAttributes);
 
-            var encoding = getEncodingFromMessageParts(messageParts);
+            var encoding = charset || getEncodingFromMessageParts(messageParts);
 
             resolve({
                 attributes: attributes,
@@ -96,7 +97,9 @@ function getEncodingFromMessageParts(messageParts) {
 
 function convertArrayToString(parts, encoding) {
     var encodedParts = parts.map(function (part) {
-        return iconvlite.decode(part, encoding || 'utf8');
+        var s = iconvlite.decode(part, encoding || 'utf8');
+        return s;
     });
+
     return encodedParts.join('');
 }

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -155,7 +155,9 @@ ImapSimple.prototype.search = function (searchCriteria, fetchOptions, callback) 
 
             function fetchCompleted() {
                 // pare array down while keeping messages in order
-                var pared = messages.filter(function (m) { return !!m; });
+                var pared = messages.filter(function (m) {
+                    return !!m;
+                });
                 resolve(pared);
             }
 
@@ -200,7 +202,7 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
         });
 
         function fetchOnMessage(msg) {
-            getMessage(msg).then(function (result) {
+            getMessage(msg, part.params && part.params.charset).then(function (result) {
                 if (result.parts.length !== 1) {
                     reject(new Error('Got ' + result.parts.length + ' parts, should get 1'));
                     return;
@@ -231,8 +233,12 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
                 }
 
                 if (encoding === '8BIT' || encoding === 'BINARY') {
-                    var charset = (part.params && part.params.charset) || 'utf-8';
-                    resolve(iconvlite.decode(new Buffer(data), charset));
+                    var charset = ((part.params && part.params.charset) || 'utf-8').toUpperCase();
+                    if (charset === 'UTF-8') {
+                        resolve(iconvlite.decode(new Buffer(data), charset));
+                    } else {
+                        resolve(data);
+                    }
                     return;
                 }
 


### PR DESCRIPTION
Hi @anttimann,

this is how I fixed the german umlaut problem in my current use-case. I'm just unsure if it would break any other use-case.

For me following question is bugging me: 
```
convertArrayToString => iconvlite.decode(...)
fetchOnMessage => iconvlite.decode(...)
```

So I had to de-activate the redundant `iconvlite.decode`making it work. Not sure for what reason it is actually present. 
